### PR TITLE
server: fix io error when reach the end of nbd device

### DIFF
--- a/handlers/gluster.c
+++ b/handlers/gluster.c
@@ -511,6 +511,13 @@ static void glfs_async_cbk(glfs_fd_t *gfd, ssize_t ret,
 {
     struct nbd_handler_request *req = data;
 
+    /*
+     * ENOENT for READ operation means EOF,
+     * see glusterfs commit 9fe5c6d3
+     */
+    if ((errno == ENOENT) && (req->cmd == NBD_CMD_READ))
+        errno = 0;
+
     req->done(req, -errno);
 }
 


### PR DESCRIPTION
=Reproduce Steps=
$ nbd-cli gluster list
NBD-DEVS            NBD-STAT       NBD-MAPTIME              BS-STAT        BS-SIZE        BS-RO     BS-TMO    BACKSTORE
--------            --------       -----------              -------        -------        -----     ------    ---------
/dev/nbd4           Inuse          2019-10-30 04:18:51      Live              1(G)        N         30        rep/test_pre1

$ dd if=/dev/nbd4 of=/dev/null bs=1  skip=1073741312 count=512
dd: error reading '/dev/nbd4': Input/output error
0+0 records in
0+0 records out
0 bytes copied, 0.00483762 s, 0.0 kB/s

nbd-runner.log said:
2019-10-30 04:32:13 9408 [INFO] glfs_handle_request:539: NBD_CMD_READ: offset: 1073737728, len: 4096
2019-10-30 04:33:19 9408 [INFO] glfs_async_cbk:514: ret: 4096 errno:2

This is because glusterfs 9fe5c6d3 commit "posix: Support EOF for file reading"
hacked posix readv logic, We should deal with it carefully in glfs_async_cbk.
Also refer nfs3svc_readdir_fstat_cbk in gnfs about how to use EOF.

Signed-off-by: Xie Changlong <xiechanglong@cmss.chinamobile.com>